### PR TITLE
INFR-1889 - Deploy mostly-combined with helm instead of terragrunt in aws-marketplace

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -80,10 +80,10 @@ export AWS_ECR_AUTH_TOKEN=$(aws ecr get-login-password --region us-east-1)
 terragrunt run-all --queue-include-external --working-dir examples/helm-stack -- plan
 # 4.2. Run the apply to generate the values.yaml file required for the helm installation
 terragrunt run-all --queue-include-external --working-dir examples/helm-stack -- apply
-# 4.3 Locate values.yaml and save it to VALUES_FILE_PATH 
+# 4.3. Locate values.yaml and save it to VALUES_FILE_PATH 
 export VALUES_FILE_PATH=$(find examples/helm-stack/mostly-combined/ -type f -path "*values.yaml")
-# 4.4  Get the latest version from https://github.com/mostly-ai/mostlyai/releases
-# 4.5 Replace the [version] with the one retrieved in the previous step and run the install of the MOSTLY AI Data Intelligence Platform
+# 4.4.  Get the latest version from https://github.com/mostly-ai/mostlyai/releases
+# 4.5. Replace the [version] with the one retrieved in the previous step and run the install of the MOSTLY AI Data Intelligence Platform
 helm upgrade --install mostly-ai oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/mostly-ai/platform/mostly-combined/[version] \
   --values $VALUES_FILE_PATH \
   --namespace mostly-ai

--- a/examples/README.md
+++ b/examples/README.md
@@ -86,7 +86,7 @@ export VALUES_FILE_PATH=$(find examples/helm-stack/mostly-combined/ -type f -pat
 # 4.5. Replace the [version] with the one retrieved in the previous step and run the install of the MOSTLY AI Data Intelligence Platform
 helm upgrade --install mostly-ai oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/mostly-ai/platform/mostly-combined/[version] \
   --values $VALUES_FILE_PATH \
-  --namespace mostly-ai
+  --namespace mostlyai
 
 # 5. Install the Post-Helm Stack.
 # 5.1. Fetch the ALB DNS name from the Ingress resource's status field.

--- a/examples/README.md
+++ b/examples/README.md
@@ -81,7 +81,7 @@ terragrunt run-all --queue-include-external --working-dir examples/helm-stack --
 # 4.2. Run the apply to generate the values.yaml file required for the helm installation
 terragrunt run-all --queue-include-external --working-dir examples/helm-stack -- apply
 # 4.3. Locate values.yaml and save it to VALUES_FILE_PATH 
-export VALUES_FILE_PATH=$(find examples/helm-stack/mostly-combined/ -type f -path "*values.yaml")
+export VALUES_FILE_PATH=$(find examples/helm-stack/mostly-combined/values -type f -path "*values.yaml")
 # 4.4.  Get the latest version from https://github.com/mostly-ai/mostlyai/releases
 # 4.5. Replace the [version] with the one retrieved in the previous step and run the install of the MOSTLY AI Data Intelligence Platform
 helm upgrade --install mostly-ai oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/mostly-ai/platform/mostly-combined/[version] \

--- a/examples/README.md
+++ b/examples/README.md
@@ -80,12 +80,10 @@ export AWS_ECR_AUTH_TOKEN=$(aws ecr get-login-password --region us-east-1)
 terragrunt run-all --queue-include-external --working-dir examples/helm-stack -- plan
 # 4.2. Run the apply to generate the values.yaml file required for the helm installation
 terragrunt run-all --queue-include-external --working-dir examples/helm-stack -- apply
-# 4.3. Locate values.yaml and save it to VALUES_FILE_PATH 
-export VALUES_FILE_PATH=$(find examples/helm-stack/mostly-combined/values -type f -path "*values.yaml")
-# 4.4.  Get the latest version from https://github.com/mostly-ai/mostlyai/releases
-# 4.5. Replace the [version] with the one retrieved in the previous step and run the install of the MOSTLY AI Data Intelligence Platform
+# 4.3.  Get the latest version from https://github.com/mostly-ai/mostlyai/releases
+# 4.4. Replace the [version] with the one retrieved in the previous step and run the install of the MOSTLY AI Data Intelligence Platform
 helm upgrade --install mostly-ai oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/mostly-ai/platform/mostly-combined \
-  --values $VALUES_FILE_PATH \
+  --values examples/helm-stack/mostly-combined/values/values.yaml \
   --version [version] \
   --namespace mostlyai
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -84,8 +84,9 @@ terragrunt run-all --queue-include-external --working-dir examples/helm-stack --
 export VALUES_FILE_PATH=$(find examples/helm-stack/mostly-combined/values -type f -path "*values.yaml")
 # 4.4.  Get the latest version from https://github.com/mostly-ai/mostlyai/releases
 # 4.5. Replace the [version] with the one retrieved in the previous step and run the install of the MOSTLY AI Data Intelligence Platform
-helm upgrade --install mostly-ai oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/mostly-ai/platform/mostly-combined/[version] \
+helm upgrade --install mostly-ai oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/mostly-ai/platform/mostly-combined \
   --values $VALUES_FILE_PATH \
+  --version [version] \
   --namespace mostlyai
 
 # 5. Install the Post-Helm Stack.

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,7 +35,7 @@ Finally, it would be best if you have checked the [repository guide](../README.m
 
 ## Installation
 
-Overall, the installation process is straightforward and relies on deploying the Terragrunt stacks in the order described [above](#terragrunt-stacks). If using the examples directly, make sure to change the [common.hcl](./common.hcl) file with your own values: environment (you can create a global unique name for your organization), aws_region and hosted_zone. Also, change the [extra-locals.hcl](./extra-locals.hcl) file to define the allowed IP ranges as CIDR blocks in the format ["1.1.1.1/1","2.2.2.2/2","3.3.3.3/3"]. 
+Overall, the installation process is straightforward and relies on deploying the Terragrunt stacks in the order described [above](#terragrunt-stacks). If using the examples directly, make sure to change the [common.hcl](./common.hcl) file with your own values: environment (you can create a global unique name for your organization), aws_region and hosted_zone. Also, change the [extra-locals.hcl](./extra-locals.hcl) file to define the allowed IP ranges as CIDR blocks in the format ["1.1.1.1/1","2.2.2.2/2","3.3.3.3/3"].
 
 The credentials for the initial superadmin are defined in the [`helm-stack/mostly-combined/terragrunt.hcl`](./helm-stack/mostly-combined/terragrunt.hcl) file and by default are set to: `superadmin@YOURHOSTEDZONE` with a password of `defaultPassword123`. It is highly recommended to change these before proceeding with the installation.
 
@@ -80,7 +80,7 @@ export AWS_ECR_AUTH_TOKEN=$(aws ecr get-login-password --region us-east-1)
 terragrunt run-all --queue-include-external --working-dir examples/helm-stack -- plan
 # 4.2. Run the apply to generate the values.yaml file required for the helm installation
 terragrunt run-all --queue-include-external --working-dir examples/helm-stack -- apply
-# 4.3.  Get the latest version from https://github.com/mostly-ai/mostlyai/releases
+# 4.3.  Get the latest version from https://aws.amazon.com/marketplace/pp/prodview-clqfgzfzznfoc
 # 4.4. Replace the [version] with the one retrieved in the previous step and run the install of the MOSTLY AI Data Intelligence Platform
 helm upgrade --install mostly-ai oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/mostly-ai/platform/mostly-combined \
   --values examples/helm-stack/mostly-combined/values/values.yaml \
@@ -109,7 +109,7 @@ Finally, you can setup the MostlyAI Platform with different computes to support 
 ## Frequently Asked Questions
 
 ### Question: Can I change the allowed IP range after the installation?
-Yes. You can update the Helm chart configuration and then re-apply the charts to apply the new IP range. 
+Yes. You can update the Helm chart configuration and then re-apply the charts to apply the new IP range.
 
 ### Question: I want to install the platform on an AWS account where a local network and/or VPN is already configured. Can I use this VPC instead of creating a new one?
-Yes, you can configure the platform to use an existing VPC. To do this, update the [terragrunt.hcl](./infrastructure-stack/eks/terragrunt.hcl) file with the appropriate values for `vpc_id`, `private_subnet_ids`, and `public_subnet_ids` in the `inputs` section before starting the installation. You also need to make sure that you remove the VPC creation parts from the scripts. 
+Yes, you can configure the platform to use an existing VPC. To do this, update the [terragrunt.hcl](./infrastructure-stack/eks/terragrunt.hcl) file with the appropriate values for `vpc_id`, `private_subnet_ids`, and `public_subnet_ids` in the `inputs` section before starting the installation. You also need to make sure that you remove the VPC creation parts from the scripts.

--- a/examples/README.md
+++ b/examples/README.md
@@ -78,8 +78,15 @@ aws eks update-kubeconfig --region $AWS_REGION --name mai-mplace-eks
 #      Since MOSTLY AI is installed from the AWS Marketplace Helm Registry, you will need to provide the authentication to it. This is done in the example via AWS_ECR_AUTH_TOKEN environment variable.
 export AWS_ECR_AUTH_TOKEN=$(aws ecr get-login-password --region us-east-1)
 terragrunt run-all --queue-include-external --working-dir examples/helm-stack -- plan
-# 4.2. Run the apply to install the MOSTLY AI Data Intelligence Platform and AWS Load Balancer controller
+# 4.2. Run the apply to generate the values.yaml file required for the helm installation
 terragrunt run-all --queue-include-external --working-dir examples/helm-stack -- apply
+# 4.3 Locate values.yaml and save it to VALUES_FILE_PATH 
+export VALUES_FILE_PATH=$(find examples/helm-stack/mostly-combined/ -type f -path "*values.yaml")
+# 4.4  Get the latest version from https://github.com/mostly-ai/mostlyai/releases
+# 4.5 Replace the [version] with the one retrieved in the previous step and run the install of the MOSTLY AI Data Intelligence Platform
+helm upgrade --install mostly-ai oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/mostly-ai/platform/mostly-combined/[version] \
+  --values $VALUES_FILE_PATH \
+  --namespace mostly-ai
 
 # 5. Install the Post-Helm Stack.
 # 5.1. Fetch the ALB DNS name from the Ingress resource's status field.

--- a/examples/helm-stack/aws-load-balancer-controller/terragrunt.hcl
+++ b/examples/helm-stack/aws-load-balancer-controller/terragrunt.hcl
@@ -6,11 +6,11 @@ locals {
 }
 
 inputs = {
-  service                 = "aws-load-balancer-controller"
-  namespace               = "kube-system"
-  helm_release_deploy_enabled   = true
-  helm_release_chart      = "aws-load-balancer-controller"
-  helm_release_repository = "https://aws.github.io/eks-charts"
+  service                     = "aws-load-balancer-controller"
+  namespace                   = "kube-system"
+  helm_release_deploy_enabled = true
+  helm_release_chart          = "aws-load-balancer-controller"
+  helm_release_repository     = "https://aws.github.io/eks-charts"
   helm_release_values = {
     values = {
       clusterName       = local.global.environment

--- a/examples/helm-stack/aws-load-balancer-controller/terragrunt.hcl
+++ b/examples/helm-stack/aws-load-balancer-controller/terragrunt.hcl
@@ -8,6 +8,7 @@ locals {
 inputs = {
   service                 = "aws-load-balancer-controller"
   namespace               = "kube-system"
+  helm_release_deploy_enabled   = true
   helm_release_chart      = "aws-load-balancer-controller"
   helm_release_repository = "https://aws.github.io/eks-charts"
   helm_release_values = {

--- a/examples/helm-stack/mostly-combined/terragrunt.hcl
+++ b/examples/helm-stack/mostly-combined/terragrunt.hcl
@@ -19,6 +19,7 @@ locals {
 inputs = {
   service                       = "mostlyai"
   namespace                     = "mostlyai"
+  helm_release_deploy_enabled   = false
   helm_release_chart            = "mostly-combined"
   helm_release_repository       = "oci://709825985650.dkr.ecr.us-east-1.amazonaws.com/mostly-ai/platform"
   helm_release_timeout          = 300

--- a/modules/helm/release.tf
+++ b/modules/helm/release.tf
@@ -2,6 +2,7 @@ resource "helm_release" "main" {
   # This depends_on block ensures that the local_sensitive_file is created before the helm_release.
   # This way the values can be viewed even if the helm_release fails.
   # We do not use this values file directly as it would cause helm_release to destroy this resource instead of updating it.
+  count               = var.helm_release_deploy_enabled ? 1 : 0
   depends_on          = [local_sensitive_file.main]
   name                = var.service
   repository          = var.helm_release_repository

--- a/modules/helm/values.tf
+++ b/modules/helm/values.tf
@@ -1,5 +1,5 @@
 # These values are generated for easier local troubleshooting.
 resource "local_sensitive_file" "main" {
   content  = local.values
-  filename = "${path.module}/values.yaml"
+  filename = "${path.root}/values/values.yaml"
 }

--- a/modules/helm/values.tf
+++ b/modules/helm/values.tf
@@ -1,5 +1,5 @@
 # These values are generated for easier local troubleshooting.
 resource "local_sensitive_file" "main" {
   content  = local.values
-  filename = "${path.root}/values/values.yaml"
+  filename = "${path.cwd}/values/values.yaml"
 }

--- a/modules/helm/values.tf
+++ b/modules/helm/values.tf
@@ -1,5 +1,5 @@
 # These values are generated for easier local troubleshooting.
 resource "local_sensitive_file" "main" {
   content  = local.values
-  filename = "${path.cwd}/values/values.yaml"
+  filename = "../../../values.yaml"
 }

--- a/modules/helm/variables.tf
+++ b/modules/helm/variables.tf
@@ -51,3 +51,8 @@ variable "helm_release_secret_values" {
   } }
   sensitive = true
 }
+
+variable "helm_release_deploy_enabled" {
+    type = bool
+    default = false
+}


### PR DESCRIPTION
**Tests:**

```
(devbox) simonaionascu@Simonas-MacBook-Pro mostly-combined % terragrunt plan 
16:18:54.087 STDOUT tofu: OpenTofu used the selected providers to generate the following execution
16:18:54.087 STDOUT tofu: plan. Resource actions are indicated with the following symbols:
16:18:54.087 STDOUT tofu:   + create
16:18:54.087 STDOUT tofu: OpenTofu will perform the following actions:
16:18:54.087 STDOUT tofu:   # local_sensitive_file.main will be created
16:18:54.088 STDOUT tofu:   + resource "local_sensitive_file" "main" {
16:18:54.088 STDOUT tofu:       + content              = (sensitive value)
16:18:54.088 STDOUT tofu:       + content_base64sha256 = (known after apply)
16:18:54.088 STDOUT tofu:       + content_base64sha512 = (known after apply)
16:18:54.088 STDOUT tofu:       + content_md5          = (known after apply)
16:18:54.088 STDOUT tofu:       + content_sha1         = (known after apply)
16:18:54.088 STDOUT tofu:       + content_sha256       = (known after apply)
16:18:54.088 STDOUT tofu:       + content_sha512       = (known after apply)
16:18:54.088 STDOUT tofu:       + directory_permission = "0700"
16:18:54.088 STDOUT tofu:       + file_permission      = "0700"
16:18:54.088 STDOUT tofu:       + filename             = "./values.yaml"
16:18:54.088 STDOUT tofu:       + id                   = (known after apply)
16:18:54.088 STDOUT tofu:     }
16:18:54.088 STDOUT tofu: Plan: 1 to add, 0 to change, 0 to destroy.
16:18:54.088 STDOUT tofu: 
16:18:54.088 STDOUT tofu: Changes to Outputs:
16:18:54.088 STDOUT tofu:   + values = (sensitive value)
16:18:54.088 STDOUT tofu: 
16:18:54.088 STDOUT tofu: ─────────────────────────────────────────────────────────────────────────────
16:18:54.088 STDOUT tofu: Note: You didn't use the -out option to save this plan, so OpenTofu can't
16:18:54.088 STDOUT tofu: guarantee to take exactly these actions if you run "tofu apply" now.
```